### PR TITLE
docs: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use {
 
 ```lua
 require('notes-compile').setup {
-  file_name = 'master.pdf'
+  file_name = 'master.pdf',
   skip = { 'readme.md' },
   events = {},
   pandoc_args = {


### PR DESCRIPTION
fixed a type in Default Configuration, `missing semi comma`